### PR TITLE
[FEATURE] 유저, 인증 기능 구현

### DIFF
--- a/core/core-api/build.gradle
+++ b/core/core-api/build.gradle
@@ -7,5 +7,13 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // JWT
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/annotation/Business.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/annotation/Business.java
@@ -1,0 +1,17 @@
+package com.nerd.favorite18.core.api._common.annotation;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Service
+public @interface Business {
+    @AliasFor(annotation = Service.class)
+    String value() default "";
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/annotation/Converter.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/annotation/Converter.java
@@ -1,0 +1,17 @@
+package com.nerd.favorite18.core.api._common.annotation;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Service
+public @interface Converter {
+    @AliasFor(annotation = Service.class)
+    String value() default "";
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/annotation/UserSession.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/annotation/UserSession.java
@@ -1,0 +1,11 @@
+package com.nerd.favorite18.core.api._common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserSession {
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/client/OAuth2Client.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/client/OAuth2Client.java
@@ -1,0 +1,59 @@
+package com.nerd.favorite18.core.api._common.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class OAuth2Client {
+    private final static String AUTHORIZATION_URI = "https://accounts.google.com/o/oauth2/auth";
+    private final static String TOKEN_URI = "https://oauth2.googleapis.com/token";
+    private final static String USER_INFO_URI = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+    @Value("${oauth2.google.client-id}")
+    private String clientId;
+
+    @Value("${oauth2.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth2.google.redirect-uri}")
+    private String redirectUri;
+
+    public URI getAuthorizationUri() {
+        return UriComponentsBuilder.fromUriString(AUTHORIZATION_URI)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .queryParam("scope", "email profile")
+                .build()
+                .toUri();
+    }
+
+    public Map<String, String> getAccessToken(String authorizationCode) {
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, String> request = new HashMap<>();
+
+        request.put("client_id", clientId);
+        request.put("client_secret", clientSecret);
+        request.put("redirect_uri", redirectUri);
+        request.put("grant_type", "authorization_code");
+        request.put("code", authorizationCode);
+
+        return restTemplate.postForObject(TOKEN_URI, request, Map.class);
+    }
+
+    public Map<String, Object> getUserInfo(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        String uri = UriComponentsBuilder.fromUriString(USER_INFO_URI)
+                .queryParam("access_token", accessToken)
+                .toUriString();
+
+        return restTemplate.getForObject(uri, Map.class);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/config/RestTemplateConfig.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.nerd.favorite18.core.api._common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/config/WebConfig.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/config/WebConfig.java
@@ -1,0 +1,47 @@
+package com.nerd.favorite18.core.api._common.config;
+
+import com.nerd.favorite18.core.api._common.intercepter.AuthorizationInterceptor;
+import com.nerd.favorite18.core.api._common.resolver.UserSessionResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthorizationInterceptor authorizationInterceptor;
+    private final UserSessionResolver userSessionResolver;
+
+    private final List<String> OPEN_API = List.of(
+            "/open-api/**"
+    );
+
+    private final List<String> DEFAULT_EXCLUDE = List.of(
+            "/",
+            "/favicon.ico",
+            "/error"
+    );
+
+    private final List<String> SWAGGER = List.of(
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
+    );
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authorizationInterceptor)
+                .excludePathPatterns(OPEN_API)
+                .excludePathPatterns(DEFAULT_EXCLUDE)
+                .excludePathPatterns(SWAGGER);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userSessionResolver);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/intercepter/AuthorizationInterceptor.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/intercepter/AuthorizationInterceptor.java
@@ -1,0 +1,63 @@
+package com.nerd.favorite18.core.api._common.intercepter;
+
+import com.nerd.favorite18.core.api.jwt.business.JwtBusiness;
+import com.nerd.favorite18.core.api.support.error.CoreApiException;
+import com.nerd.favorite18.core.api.support.error.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
+
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AuthorizationInterceptor implements HandlerInterceptor {
+    private final JwtBusiness jwtBusiness;
+
+    /**
+     * [ 로그인 인증 인터셉터 ]
+     * <br/>
+     * WebConfig 에 지정된 주소로 요청시, 헤더를 확인하여 Jwt 인증여부를 확인하는 인터셉터입니다.<br/>
+     *
+     * @param request current HTTP request
+     * @param response current HTTP response
+     * @param handler chosen handler to execute, for type and/or instance evaluation
+     * @return 인터셉터 확인 값
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        log.info("Authorization Interceptor url : {}", request.getRequestURI());
+
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
+        if (handler instanceof ResourceHttpRequestHandler) {
+            return true;
+        }
+
+        final String accessToken = request.getHeader("authorization-token");
+        if (accessToken == null) {
+            throw new CoreApiException(ErrorType.AUTHORIZATION_TOKEN_NOT_FOUND);
+        }
+
+        Long userId = jwtBusiness.validationAccessToken(accessToken);
+
+        if(userId != null) {
+            final RequestAttributes requestContext = Objects.requireNonNull(RequestContextHolder.getRequestAttributes());
+            requestContext.setAttribute("userId", userId, RequestAttributes.SCOPE_REQUEST);
+
+            return true;
+        }
+
+        throw new CoreApiException(ErrorType.BAD_REQUEST);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/resolver/UserSessionResolver.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/resolver/UserSessionResolver.java
@@ -1,0 +1,46 @@
+package com.nerd.favorite18.core.api._common.resolver;
+
+import com.nerd.favorite18.core.api._common.annotation.UserSession;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.api.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class UserSessionResolver implements HandlerMethodArgumentResolver {
+    private final UserService userService;
+
+    /**
+     * [ 유저세션 리졸버 ]
+     * <br />
+     * WebConfig 에 지정된 주소로 요청시, UserSession 어노테이션을 확인하고 인터셉터에서 전달받은 유저정보를 각 컨트롤러에 전달합니다. <br />
+     *
+     * @param parameter the method parameter to check
+     * @return 확인 값
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        var annotation = parameter.hasParameterAnnotation(UserSession.class);
+        var parameterType = parameter.getParameterType().equals(UserDto.class);
+
+        return (annotation && parameterType);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final RequestAttributes requestContext = RequestContextHolder.getRequestAttributes();
+        final Object userId = requestContext.getAttribute("userId", RequestAttributes.SCOPE_REQUEST);
+        final UserDto userDto = userService.getUserWithThrow(Long.parseLong(userId.toString()));
+
+        // 사용자 정보 세팅
+        return userDto;
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/resolver/UserSessionResolver.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/resolver/UserSessionResolver.java
@@ -1,6 +1,8 @@
 package com.nerd.favorite18.core.api._common.resolver;
 
 import com.nerd.favorite18.core.api._common.annotation.UserSession;
+import com.nerd.favorite18.core.api.support.error.CoreApiException;
+import com.nerd.favorite18.core.api.support.error.ErrorType;
 import com.nerd.favorite18.core.api.user.dto.UserDto;
 import com.nerd.favorite18.core.api.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +30,8 @@ public class UserSessionResolver implements HandlerMethodArgumentResolver {
      */
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        var annotation = parameter.hasParameterAnnotation(UserSession.class);
-        var parameterType = parameter.getParameterType().equals(UserDto.class);
+        boolean annotation = parameter.hasParameterAnnotation(UserSession.class);
+        boolean parameterType = parameter.getParameterType().equals(UserDto.class);
 
         return (annotation && parameterType);
     }
@@ -37,7 +39,11 @@ public class UserSessionResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final RequestAttributes requestContext = RequestContextHolder.getRequestAttributes();
+
+        if (requestContext == null) throw new CoreApiException(ErrorType.DEFAULT_ERROR);
         final Object userId = requestContext.getAttribute("userId", RequestAttributes.SCOPE_REQUEST);
+
+        if (userId == null) throw new CoreApiException(ErrorType.DEFAULT_ERROR);
         final UserDto userDto = userService.getUserWithThrow(Long.parseLong(userId.toString()));
 
         // 사용자 정보 세팅

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/business/AuthBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/business/AuthBusiness.java
@@ -1,0 +1,87 @@
+package com.nerd.favorite18.core.api.auth.business;
+
+import com.nerd.favorite18.core.api._common.annotation.Business;
+import com.nerd.favorite18.core.api._common.client.OAuth2Client;
+import com.nerd.favorite18.core.api.auth.dto.AuthRefreshRequest;
+import com.nerd.favorite18.core.api.auth.model.GoogleUserInfo;
+import com.nerd.favorite18.core.api.jwt.business.JwtBusiness;
+import com.nerd.favorite18.core.api.jwt.dto.JwtRefreshResponse;
+import com.nerd.favorite18.core.api.jwt.dto.JwtResponse;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.api.user.dto.request.UserRegisterRequest;
+import com.nerd.favorite18.core.api.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Business
+public class AuthBusiness {
+    private final JwtBusiness jwtBusiness;
+    private final UserService userService;
+
+    private final OAuth2Client oauth2Client;
+
+    /**
+     * [ 로그인 요청 ]
+     * <br/>
+     * 1. 구글 OAuth2.0 로그인 요청 클라이언트 실행 <br/>
+     *
+     * @return Redirect URI
+     */
+    public URI login() {
+        return oauth2Client.getAuthorizationUri();
+    }
+
+    /**
+     * [ 콜백 로그인 ]
+     * <br/>
+     * 1. OAuth2.0 로그인 진행 후 리다이렉트 되어 실행되는 로직 <br/>
+     * 2. 구글 API 에서 AccessToken 받음 <br/>
+     * 3. 전달받은 AccessToken 으로 유저정보 API 실행 <br/>
+     * 4. 구글 유저정보 기반으로 DB 에서 유저 조회 <br/>
+     * 5. 유저 없으면 회원가입 진행 후 유저반환 <br/>
+     * 6. 유저 있으면 바로 유저 조회결과 반환 <br/>
+     * 7. 반환된 유저정보 기준으로 Jwt 토큰 발행 <br/>
+     *
+     * @param authorizationCode 구글로 부터 전달받은 인증코드
+     * @return JwtResponse JWT 토큰 발행
+     */
+    public JwtResponse callbackGoogle(String authorizationCode) {
+        Map<String, String> tokenResponse = oauth2Client.getAccessToken(authorizationCode);
+
+        String accessToken = tokenResponse.get("access_token");
+        GoogleUserInfo googleUserInfo = new GoogleUserInfo(oauth2Client.getUserInfo(accessToken));
+
+        // 구글 유저 정보 기반으로 유저를 조회
+        UserDto userDto;
+        try {
+            userDto = userService.getUserWithThrow(googleUserInfo.getSubId(), googleUserInfo.getEmail());
+        } catch (RuntimeException e) {
+            // 조회되지 않으면 강제 회원가입 후 유저 반환
+            userDto = userService.saveUser(UserRegisterRequest.of(
+                    googleUserInfo.getSubId(), googleUserInfo.getEmail(), googleUserInfo.getName(), googleUserInfo.getThumbnail())
+            );
+        }
+
+        // Jwt 토큰 발행
+        return jwtBusiness.issueToken(userDto);
+    }
+
+    /**
+     * [ 리프레쉬 토큰 발행 ]
+     * <br/>
+     * 1. 클라이언트로 부터 전달받은 리프레쉬 토큰을 기준으로 새로운 액세스 토큰을 반환 <br/>
+     *
+     * @param request 리프레쉬 토큰
+     * @return 새로운 액세스 토큰
+     */
+    public JwtRefreshResponse refreshToken(AuthRefreshRequest request) {
+        final JwtRefreshResponse jwtRefreshResponse = jwtBusiness.issueRefreshToken(request.getRefreshToken());
+
+        return jwtRefreshResponse;
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/business/AuthBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/business/AuthBusiness.java
@@ -2,7 +2,8 @@ package com.nerd.favorite18.core.api.auth.business;
 
 import com.nerd.favorite18.core.api._common.annotation.Business;
 import com.nerd.favorite18.core.api._common.client.OAuth2Client;
-import com.nerd.favorite18.core.api.auth.dto.AuthRefreshRequest;
+import com.nerd.favorite18.core.api.auth.dto.request.AuthRefreshRequest;
+import com.nerd.favorite18.core.api.auth.dto.response.AuthGoogleAccessTokenResponse;
 import com.nerd.favorite18.core.api.auth.model.GoogleUserInfo;
 import com.nerd.favorite18.core.api.jwt.business.JwtBusiness;
 import com.nerd.favorite18.core.api.jwt.dto.JwtRefreshResponse;
@@ -14,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
-import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -51,9 +51,9 @@ public class AuthBusiness {
      * @return JwtResponse JWT 토큰 발행
      */
     public JwtResponse callbackGoogle(String authorizationCode) {
-        Map<String, String> tokenResponse = oauth2Client.getAccessToken(authorizationCode);
+        AuthGoogleAccessTokenResponse tokenResponse = oauth2Client.getAccessToken(authorizationCode);
 
-        String accessToken = tokenResponse.get("access_token");
+        String accessToken = tokenResponse.getAccessToken();
         GoogleUserInfo googleUserInfo = new GoogleUserInfo(oauth2Client.getUserInfo(accessToken));
 
         // 구글 유저 정보 기반으로 유저를 조회

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthController.java
@@ -2,7 +2,7 @@ package com.nerd.favorite18.core.api.auth.controller;
 
 import com.nerd.favorite18.core.api._common.annotation.UserSession;
 import com.nerd.favorite18.core.api.auth.business.AuthBusiness;
-import com.nerd.favorite18.core.api.auth.dto.AuthRefreshRequest;
+import com.nerd.favorite18.core.api.auth.dto.request.AuthRefreshRequest;
 import com.nerd.favorite18.core.api.jwt.dto.JwtRefreshResponse;
 import com.nerd.favorite18.core.api.support.response.ApiResponse;
 import com.nerd.favorite18.core.api.user.dto.UserDto;

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.nerd.favorite18.core.api.auth.controller;
+
+import com.nerd.favorite18.core.api._common.annotation.UserSession;
+import com.nerd.favorite18.core.api.auth.business.AuthBusiness;
+import com.nerd.favorite18.core.api.auth.dto.AuthRefreshRequest;
+import com.nerd.favorite18.core.api.jwt.dto.JwtRefreshResponse;
+import com.nerd.favorite18.core.api.support.response.ApiResponse;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+    private final AuthBusiness authBusiness;
+
+    @PostMapping("/refresh-token")
+    public ApiResponse<JwtRefreshResponse> refreshToken(@UserSession UserDto user, @RequestBody AuthRefreshRequest request) {
+        final JwtRefreshResponse jwtRefreshResponse = authBusiness.refreshToken(request);
+
+        return ApiResponse.success(jwtRefreshResponse);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthOpenApiController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthOpenApiController.java
@@ -19,8 +19,6 @@ import java.net.URI;
 public class AuthOpenApiController {
     private final AuthBusiness authBusiness;
 
-
-
     @GetMapping("/login")
     public URI login() {
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthOpenApiController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/controller/AuthOpenApiController.java
@@ -1,0 +1,36 @@
+package com.nerd.favorite18.core.api.auth.controller;
+
+import com.nerd.favorite18.core.api.auth.business.AuthBusiness;
+import com.nerd.favorite18.core.api.jwt.dto.JwtResponse;
+import com.nerd.favorite18.core.api.support.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/open-api/auth")
+@RestController
+public class AuthOpenApiController {
+    private final AuthBusiness authBusiness;
+
+
+
+    @GetMapping("/login")
+    public URI login() {
+
+        return authBusiness.login();
+    }
+
+    @GetMapping("/login/oauth2/code/google")
+    public ApiResponse<JwtResponse> callbackGoogle(@RequestParam("code") String authorizationCode) {
+        final JwtResponse jwtResponse = authBusiness.callbackGoogle(authorizationCode);
+
+        return ApiResponse.success(jwtResponse);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/AuthRefreshRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/AuthRefreshRequest.java
@@ -1,0 +1,12 @@
+package com.nerd.favorite18.core.api.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthRefreshRequest {
+    private String refreshToken;
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/request/AuthGoogleAccessTokenRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/request/AuthGoogleAccessTokenRequest.java
@@ -1,0 +1,26 @@
+package com.nerd.favorite18.core.api.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthGoogleAccessTokenRequest {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String grantType;
+    private String code;
+
+    public static AuthGoogleAccessTokenRequest of(
+            String clientId,
+            String clientSecret,
+            String redirectUri,
+            String grantType,
+            String code
+    ) {
+        return new AuthGoogleAccessTokenRequest(clientId, clientSecret, redirectUri, grantType, code);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/request/AuthRefreshRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/request/AuthRefreshRequest.java
@@ -1,4 +1,4 @@
-package com.nerd.favorite18.core.api.auth.dto;
+package com.nerd.favorite18.core.api.auth.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/response/AuthGoogleAccessTokenResponse.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/dto/response/AuthGoogleAccessTokenResponse.java
@@ -1,0 +1,20 @@
+package com.nerd.favorite18.core.api.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthGoogleAccessTokenResponse {
+    private String access_token;
+    private String expires_in;
+    private String scope;
+    private String token_type;
+    private String id_token;
+
+    public String getAccessToken() {
+        return this.access_token;
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/model/GoogleUserInfo.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/model/GoogleUserInfo.java
@@ -1,0 +1,40 @@
+package com.nerd.favorite18.core.api.auth.model;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getSubId() {
+        return getProvider() + "_" + getProviderId();
+    }
+
+    public String getThumbnail() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/model/OAuth2UserInfo.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/model/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.nerd.favorite18.core.api.auth.model;
+
+public interface OAuth2UserInfo {
+    String getProvider();
+    String getProviderId();
+    String getSubId();
+    String getEmail();
+    String getName();
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/business/JwtBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/business/JwtBusiness.java
@@ -1,0 +1,62 @@
+package com.nerd.favorite18.core.api.jwt.business;
+
+import com.nerd.favorite18.core.api._common.annotation.Business;
+import com.nerd.favorite18.core.api.jwt.converter.JwtConverter;
+import com.nerd.favorite18.core.api.jwt.dto.JwtRefreshResponse;
+import com.nerd.favorite18.core.api.jwt.dto.JwtResponse;
+import com.nerd.favorite18.core.api.jwt.model.Token;
+import com.nerd.favorite18.core.api.jwt.service.JwtService;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Business
+public class JwtBusiness {
+    private final JwtService jwtService;
+    private final JwtConverter jwtConverter;
+
+    /**
+     * [ JWT 발행 ]
+     * <br/>
+     * 1. 유저정보를 기반으로 액세스 토큰과 리프레쉬 토큰을 생성하여 반환<br/>
+     *
+     * @param userDto 유저정보
+     * @return Jwt 토큰
+     */
+    public JwtResponse issueToken(UserDto userDto) {
+        final Token accessToken = jwtService.issueAccessToken(userDto.getId());
+        final Token refreshToken = jwtService.issueRefreshToken(userDto.getId());
+
+        return jwtConverter.toResponse(accessToken, refreshToken);
+    }
+
+    /**
+     * [ 리프레쉬 토큰 발행 ]
+     * <br/>
+     * 1. 리프레쉬 토큰 인증 진행<br/>
+     * 2. 인증이 완료되면 새로운 액세스토큰 발행<br/>
+     *
+     * @param refreshToken 리프레쉬 토큰
+     * @return 새로운 액세스 토큰
+     */
+    public JwtRefreshResponse issueRefreshToken(String refreshToken) {
+        final Long userId = jwtService.validationToken(refreshToken);
+        final Token newAccessToken = jwtService.issueAccessToken(userId);
+
+        return jwtConverter.toResponse(newAccessToken);
+    }
+
+    /**
+     * [토큰 인증 진행]
+     * <br/>
+     * 1. 액세스토큰 인증 진행<br/>
+     *
+     * @param accessToken 액세스토큰
+     * @return 유저 id
+     */
+    public Long validationAccessToken(String accessToken) {
+        final Long userId = jwtService.validationToken(accessToken);
+
+        return userId;
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/converter/JwtConverter.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/converter/JwtConverter.java
@@ -1,0 +1,32 @@
+package com.nerd.favorite18.core.api.jwt.converter;
+
+import com.nerd.favorite18.core.api._common.annotation.Converter;
+import com.nerd.favorite18.core.api.jwt.dto.JwtRefreshResponse;
+import com.nerd.favorite18.core.api.jwt.dto.JwtResponse;
+import com.nerd.favorite18.core.api.jwt.model.Token;
+
+import java.util.Objects;
+
+@Converter
+public class JwtConverter {
+    public JwtResponse toResponse(Token accessToken, Token refreshToken) {
+        Objects.requireNonNull(accessToken, () -> {throw new RuntimeException();});
+        Objects.requireNonNull(refreshToken, () -> {throw new RuntimeException();});
+
+        return JwtResponse.of(
+                accessToken.getToken(),
+                accessToken.getExpiredAt(),
+                refreshToken.getToken(),
+                refreshToken.getExpiredAt()
+        );
+    }
+
+    public JwtRefreshResponse toResponse(Token accessToken) {
+        Objects.requireNonNull(accessToken, () -> {throw new RuntimeException();});
+
+        return JwtRefreshResponse.of(
+                accessToken.getToken(),
+                accessToken.getExpiredAt()
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/dto/JwtRefreshResponse.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/dto/JwtRefreshResponse.java
@@ -1,0 +1,25 @@
+package com.nerd.favorite18.core.api.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtRefreshResponse {
+    private String accessToken;
+    private LocalDateTime accessTokenExpiredAt;
+
+    public static JwtRefreshResponse of(
+            String accessToken,
+            LocalDateTime accessTokenExpiredAt
+    ) {
+        return new JwtRefreshResponse(
+                accessToken,
+                accessTokenExpiredAt
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/dto/JwtResponse.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/dto/JwtResponse.java
@@ -1,0 +1,31 @@
+package com.nerd.favorite18.core.api.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtResponse {
+    private String accessToken;
+    private LocalDateTime accessTokenExpiredAt;
+    private String refreshToken;
+    private LocalDateTime refreshTokenExpiredAt;
+
+    public static JwtResponse of(
+            String accessToken,
+            LocalDateTime accessTokenExpiredAt,
+            String refreshToken,
+            LocalDateTime refreshTokenExpiredAt
+    ) {
+        return new JwtResponse(
+                accessToken,
+                accessTokenExpiredAt,
+                refreshToken,
+                refreshTokenExpiredAt
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/helper/TokenHelper.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/helper/TokenHelper.java
@@ -1,0 +1,11 @@
+package com.nerd.favorite18.core.api.jwt.helper;
+
+import com.nerd.favorite18.core.api.jwt.model.Token;
+
+import java.util.Map;
+
+public interface TokenHelper {
+    Token issueAccessToken(Map<String, Object> data);
+    Token issueRefreshToken(Map<String, Object> data);
+    Map<String, Object> validationTokenWithThrow(String token);
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/helper/TokenHelperImpl.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/helper/TokenHelperImpl.java
@@ -1,0 +1,83 @@
+package com.nerd.favorite18.core.api.jwt.helper;
+
+import com.nerd.favorite18.core.api.jwt.model.Token;
+import com.nerd.favorite18.core.api.support.error.CoreApiException;
+import com.nerd.favorite18.core.api.support.error.ErrorType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.sql.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class TokenHelperImpl implements TokenHelper {
+    @Value("${token.secret.key}")
+    private String secretKey;
+
+    @Value("${token.access-token.plus-hour}")
+    private Long accessTokenPlusHour;
+
+    @Value("${token.refresh-token.plus-hour}")
+    private Long refreshTokenPlusHour;
+
+    @Override
+    public Token issueAccessToken(Map<String, Object> data) {
+        final LocalDateTime expiredLocalDateTime = LocalDateTime.now().plusHours(accessTokenPlusHour);
+
+        return getTokenDto(data, expiredLocalDateTime);
+    }
+
+    @Override
+    public Token issueRefreshToken(Map<String, Object> data) {
+        final LocalDateTime expiredLocalDateTime = LocalDateTime.now().plusHours(refreshTokenPlusHour);
+
+        return getTokenDto(data, expiredLocalDateTime);
+    }
+
+    @Override
+    public Map<String, Object> validationTokenWithThrow(String token) {
+        final SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        final JwtParser parser = Jwts.parserBuilder().setSigningKey(key).build();
+
+        try {
+            final Jws<Claims> result = parser.parseClaimsJws(token);
+
+            return new HashMap<>(result.getBody());
+        } catch (Exception e) {
+            if (e instanceof SignatureException) {
+                // 토큰이 유효하지 않을 때
+                throw new CoreApiException(ErrorType.INVALID_TOKEN);
+            } else if (e instanceof ExpiredJwtException) {
+                // 만료된 토큰
+                throw new CoreApiException(ErrorType.EXPIRED_TOKEN);
+            } else {
+                // 그 외
+                throw new CoreApiException(ErrorType.TOKEN_EXCEPTION);
+            }
+        }
+    }
+
+    private Token getTokenDto(Map<String, Object> data, LocalDateTime expiredLocalDateTime) {
+        var expiredAt = Date.from(expiredLocalDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        var key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        var jwtToken = Jwts.builder()
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setClaims(data)
+                .setExpiration(expiredAt)
+                .compact();
+
+        return Token.builder()
+                .token(jwtToken)
+                .expiredAt(expiredLocalDateTime)
+                .build();
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/model/Token.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/model/Token.java
@@ -1,0 +1,17 @@
+package com.nerd.favorite18.core.api.jwt.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token {
+    private String token;
+    private LocalDateTime expiredAt;
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/service/JwtService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/jwt/service/JwtService.java
@@ -1,0 +1,41 @@
+package com.nerd.favorite18.core.api.jwt.service;
+
+import com.nerd.favorite18.core.api.jwt.helper.TokenHelper;
+import com.nerd.favorite18.core.api.jwt.model.Token;
+import com.nerd.favorite18.core.api.support.error.CoreApiException;
+import com.nerd.favorite18.core.api.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+    private final TokenHelper tokenHelper;
+
+    public Token issueAccessToken(Long userId) {
+        var data = new HashMap<String, Object>();
+        data.put("userId", userId);
+
+        return tokenHelper.issueAccessToken(data);
+    }
+
+    public Token issueRefreshToken(Long userId) {
+        var data = new HashMap<String, Object>();
+        data.put("userId", userId);
+
+        return tokenHelper.issueRefreshToken(data);
+    }
+
+    public Long validationToken(String token) {
+        final Map<String, Object> map = tokenHelper.validationTokenWithThrow(token);
+        final Object userId = map.get("userId");
+
+        Objects.requireNonNull(userId, () -> {throw new CoreApiException(ErrorType.NULL_POINT);});
+
+        return Long.parseLong(userId.toString());
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/support/error/ErrorCode.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/support/error/ErrorCode.java
@@ -1,7 +1,12 @@
 package com.nerd.favorite18.core.api.support.error;
 
 public enum ErrorCode {
-
+    E1404,
+    E2000,
+    E2001,
+    E2002,
+    E2003,
+    E400,
     E500
 
 }

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/support/error/ErrorType.java
@@ -4,9 +4,16 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.http.HttpStatus;
 
 public enum ErrorType {
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, ErrorCode.E1404, "User is not fonded.", LogLevel.ERROR),
 
-    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
-            LogLevel.ERROR);
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, ErrorCode.E2000, "Token is invalided.", LogLevel.ERROR),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, ErrorCode.E2001, "Token is expired.", LogLevel.ERROR),
+    TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E2002, "An unexpected error with token.", LogLevel.ERROR),
+    AUTHORIZATION_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, ErrorCode.E2003, "No token in the authentication header.", LogLevel.ERROR),
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, ErrorCode.E400, "Bad Request", LogLevel.ERROR),
+    NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "Null point error.", LogLevel.ERROR),
+    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR);
 
     private final HttpStatus status;
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/support/response/ApiResponse.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/support/response/ApiResponse.java
@@ -17,7 +17,7 @@ public class ApiResponse<S> {
         this.error = error;
     }
 
-    public static ApiResponse<?> success() {
+    public static ApiResponse<Void> success() {
         return new ApiResponse<>(ResultType.SUCCESS, null, null);
     }
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/business/UserBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/business/UserBusiness.java
@@ -1,0 +1,17 @@
+package com.nerd.favorite18.core.api.user.business;
+
+import com.nerd.favorite18.core.api._common.annotation.Business;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.api.user.dto.request.UserUpdateNicknameRequest;
+import com.nerd.favorite18.core.api.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Business
+public class UserBusiness {
+    private final UserService userService;
+
+    public void updateNickname(UserDto user, UserUpdateNicknameRequest request) {
+        userService.updateNickname(user, request);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/controller/UserController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.nerd.favorite18.core.api.user.controller;
+
+import com.nerd.favorite18.core.api._common.annotation.UserSession;
+import com.nerd.favorite18.core.api.support.response.ApiResponse;
+import com.nerd.favorite18.core.api.user.business.UserBusiness;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.api.user.dto.request.UserUpdateNicknameRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+@RestController
+public class UserController {
+    private final UserBusiness userBusiness;
+
+    @GetMapping("/me")
+    public ApiResponse<UserDto> me(@UserSession UserDto user) {
+        return ApiResponse.success(user);
+    }
+
+    @PutMapping("/set-nickname")
+    public ApiResponse<Void> updateNickname(@UserSession UserDto user, @RequestBody UserUpdateNicknameRequest request) {
+        userBusiness.updateNickname(user, request);
+
+        return ApiResponse.success();
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/converter/UserConverter.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/converter/UserConverter.java
@@ -1,0 +1,44 @@
+package com.nerd.favorite18.core.api.user.converter;
+
+import com.nerd.favorite18.core.api._common.annotation.Converter;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.api.user.dto.request.UserRegisterRequest;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import com.nerd.favorite18.storage.db.core.user.type.UserRole;
+import com.nerd.favorite18.storage.db.core.user.type.UserStatus;
+
+import java.util.Optional;
+
+@Converter
+public class UserConverter {
+    public User toEntity(UserRegisterRequest request) {
+        return Optional.ofNullable(request)
+                .map(it -> User.builder()
+                        .subId(request.getSubId())
+                        .email(request.getEmail())
+                        .name(request.getName())
+                        .thumbnail(request.getThumbnail())
+                        .role(UserRole.USER)
+                        .status(UserStatus.ACTIVE)
+                        .build())
+                .orElseThrow(NullPointerException::new);
+    }
+
+    public UserDto toDto(User entity) {
+
+        return UserDto.of(
+                entity.getId(),
+                entity.getSubId(),
+                entity.getEmail(),
+                entity.getName(),
+                entity.getNickname(),
+                entity.getBirth(),
+                entity.getGender(),
+                entity.getThumbnail(),
+                entity.getRole(),
+                entity.getStatus(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/dto/UserDto.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/dto/UserDto.java
@@ -1,0 +1,58 @@
+package com.nerd.favorite18.core.api.user.dto;
+
+import com.nerd.favorite18.storage.db.core.user.type.UserGender;
+import com.nerd.favorite18.storage.db.core.user.type.UserRole;
+import com.nerd.favorite18.storage.db.core.user.type.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+    private Long id;
+    private String subId;
+    private String email;
+    private String name;
+    private String nickname;
+    private String birth;
+    private UserGender gender;
+    private String thumbnail;
+    private UserRole role;
+    private UserStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static UserDto of(
+            Long id,
+            String subId,
+            String email,
+            String name,
+            String nickname,
+            String birth,
+            UserGender gender,
+            String thumbnail,
+            UserRole role,
+            UserStatus status,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new UserDto(
+                id,
+                subId,
+                email,
+                name,
+                nickname,
+                birth,
+                gender,
+                thumbnail,
+                role,
+                status,
+                createdAt,
+                updatedAt
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/dto/request/UserRegisterRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/dto/request/UserRegisterRequest.java
@@ -1,0 +1,27 @@
+package com.nerd.favorite18.core.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisterRequest {
+    @NotBlank
+    private String subId;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    private String name;
+
+    private String thumbnail;
+
+    public static UserRegisterRequest of(String subId, String email, String name, String thumbnail) {
+        return new UserRegisterRequest(subId, email, name, thumbnail);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/dto/request/UserUpdateNicknameRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/dto/request/UserUpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.nerd.favorite18.core.api.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateNicknameRequest {
+    private String nickname;
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/service/UserService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/service/UserService.java
@@ -1,0 +1,61 @@
+package com.nerd.favorite18.core.api.user.service;
+
+import com.nerd.favorite18.core.api.support.error.CoreApiException;
+import com.nerd.favorite18.core.api.support.error.ErrorType;
+import com.nerd.favorite18.core.api.user.converter.UserConverter;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.api.user.dto.request.UserRegisterRequest;
+import com.nerd.favorite18.core.api.user.dto.request.UserUpdateNicknameRequest;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import com.nerd.favorite18.storage.db.core.user.repository.UserRepository;
+import com.nerd.favorite18.storage.db.core.user.type.UserStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final UserConverter userConverter;
+
+    @Transactional(readOnly = true)
+    public UserDto getUserWithThrow(String subId, String email) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findBySubIdAndEmailAndStatusOrderByIdDesc(subId, email, UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        return userConverter.toDto(userEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public UserDto getUserWithThrow(Long userId) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findFirstByIdAndStatusOrderByIdDesc(userId, UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        return userConverter.toDto(userEntity);
+    }
+
+    @Transactional
+    public UserDto saveUser(UserRegisterRequest request) {
+        final User userEntity = userConverter.toEntity(request);
+
+        final User newUserEntity = userRepository.save(userEntity);
+
+        return userConverter.toDto(newUserEntity);
+    }
+
+    @Transactional
+    public void updateNickname(UserDto user, UserUpdateNicknameRequest request) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findFirstByIdAndStatusOrderByIdDesc(user.getId(), UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        userEntity.updateNickname(request.getNickname());
+
+        userRepository.save(userEntity);
+    }
+}

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -15,6 +15,20 @@ server:
       max: 600
       min-spare: 100
 
+oauth2:
+  google:
+    client-id: ${OAUTH2_GOOGLE_CLIENT_ID}
+    client-secret: ${OAUTH2_GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${OAUTH2_GOOGLE_REDIRECT_URI}
+
+token:
+  secret:
+    key: ${TOKEN_SECRET_KEY}
+  access-token:
+    plus-hour: 1
+  refresh-token:
+    plus-hour: 12
+
 ---
 spring.config.activate.on-profile: local
 

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -20,6 +20,9 @@ oauth2:
     client-id: ${OAUTH2_GOOGLE_CLIENT_ID}
     client-secret: ${OAUTH2_GOOGLE_CLIENT_SECRET}
     redirect-uri: ${OAUTH2_GOOGLE_REDIRECT_URI}
+    authorization-uri: https://accounts.google.com/o/oauth2/auth
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
 
 token:
   secret:

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/entity/User.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/entity/User.java
@@ -1,0 +1,68 @@
+package com.nerd.favorite18.storage.db.core.user.entity;
+
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import com.nerd.favorite18.storage.db.core.user.type.UserGender;
+import com.nerd.favorite18.storage.db.core.user.type.UserRole;
+import com.nerd.favorite18.storage.db.core.user.type.UserStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "tbl_user")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+    @Column(length = 100, nullable = false)
+    private String subId;
+
+    @Column(length = 50, nullable = false)
+    private String email;
+
+    @Column(length = 20)
+    private String name;
+
+    @Column(length = 30)
+    private String nickname;
+
+    @Column(length = 20)
+    private String birth;
+
+    @Enumerated(EnumType.STRING)
+    private UserGender gender;
+
+    private String thumbnail;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    @Builder
+    public User(
+            String subId,
+            String email,
+            String name,
+            String nickname,
+            String birth,
+            UserGender gender,
+            String thumbnail,
+            UserRole role,
+            UserStatus status
+    ) {
+        this.subId = subId;
+        this.email = email;
+        this.name = name;
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.thumbnail = thumbnail;
+        this.role = role;
+        this.status = status;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.nerd.favorite18.storage.db.core.user.repository;
+
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import com.nerd.favorite18.storage.db.core.user.type.UserStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository  extends JpaRepository<User, Long> {
+    User findBySubIdAndEmailAndStatusOrderByIdDesc(String subId, String email, UserStatus status);
+    User findFirstByIdAndStatusOrderByIdDesc(Long userId, UserStatus status);
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/type/UserGender.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/type/UserGender.java
@@ -1,0 +1,13 @@
+package com.nerd.favorite18.storage.db.core.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserGender {
+    MEN("MEN"),
+    WOMEN("WOMEN");
+
+    private final String value;
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/type/UserRole.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/type/UserRole.java
@@ -1,0 +1,13 @@
+package com.nerd.favorite18.storage.db.core.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserRole {
+    USER("USER"),
+    ADMIN("ADMIN");
+
+    private final String value;
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/type/UserStatus.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/type/UserStatus.java
@@ -1,0 +1,15 @@
+package com.nerd.favorite18.storage.db.core.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserStatus {
+    NOT_ACTIVE("NOT_ACTIVE"),
+    ACTIVE("ACTIVE"),
+    SUSPENSION("SUSPENSION"),
+    DELETE("DELETE");
+
+    private final String value;
+}

--- a/storage/db-core/src/main/resources/db-core.yml
+++ b/storage/db-core/src/main/resources/db-core.yml
@@ -12,7 +12,7 @@ spring.config.activate.on-profile: local
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📝 PR Summary

유저 회원 가입 및 로그인 구글 OAuth 2.0 + jwt 이용해서 구현했습니다.

- User 도메인이 추가되었습니다.
- Jwt 라이브러리를 추가했습니다.
- Google OAuth2.0 + Jwt 로그인기능을 구현하였습니다.
 > 로그인 인증이 완료되면 구글 API 로 부터 받은 유저정보를 기반으로 Jwt 발행을 진행합니다.
 > 만약 회원가입되어 있지 않은 유저라면 회원가입을 자동으로 진행합니다.
- RefreshToken 기반으로 새로운 AccessToken 을 발급하는 API 를 추가했습니다.
- User 닉네임 수정 API 를 추가했습니다.

#### 🌲 Working Branch

feat/#6-oauth

#### 🌲 TODOs

- [x] DB 생성 - 우선 로컬에 Entity 만 생성하여 진행예정
- [x] Google OAuth 회원 가입 진행
- [x] 회원 닉네임 수정

### Related Issues

This resolve #6 

[BE] [FEATURE] 유저, 인증 기능 구현, @JakePark929 

#### 📚 Remarks
- 회원 탈퇴는 추후에 별도 이슈로 등록하여 진행 하겠습니다.
- 카카오톡 로그인도 같이 추가하려 했으나 초반부터 분량이 너무 많은 것 같아서 우선 구글 로그인만 진행했습니다.
  > 바로 추가할 수 있도록 결합도를 최대한 낮췄습니다. 별도 이슈 등록하여 처리하겠습니다.
- jwt secret키와 google api 키는 별도 채널로 공유하겠습니다.
- Swagger 를 등록해보려고 했는데 템플릿 설정 문제인지 적용이 되지 않습니다. 별도 이슈로 등록하여 처리 진행하겠습니다.
- 현재 구글 API 에서 생년월일, 성별 등과 같은 정보를 추가하려면 더 많은 설정이 필요해서 우선 null 로 처리합니다. 중간에 회원가입 같은 로직을 클라이언트와 함께 추가해야 될 것 같습니다. 이 부분도 미리 이슈로 등록하겠습니다.

이상 다들 리뷰 부탁드려요~
