### PR TITLE
[FEATURE] Q&A 도메인 및 사용자 측 기능 구현

### DIFF
--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/support/error/ErrorCode.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/support/error/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     E2001,
     E2002,
     E2003,
+    E3404,
     E400,
     E500
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/support/error/ErrorType.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, ErrorCode.E1404, "User is not fonded.", LogLevel.ERROR),
 
+    QNA_NOT_FOUND(HttpStatus.BAD_REQUEST, ErrorCode.E3404, "Qna is not fonded.", LogLevel.ERROR),
+
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, ErrorCode.E2000, "Token is invalided.", LogLevel.ERROR),
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, ErrorCode.E2001, "Token is expired.", LogLevel.ERROR),
     TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E2002, "An unexpected error with token.", LogLevel.ERROR),

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/business/QnaBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/business/QnaBusiness.java
@@ -1,0 +1,33 @@
+package com.nerd.favorite18.core.api.qna.business;
+
+import com.nerd.favorite18.core.api._common.annotation.Business;
+import com.nerd.favorite18.core.api.qna.dto.QnaAddRequest;
+import com.nerd.favorite18.core.api.qna.dto.QnaDto;
+import com.nerd.favorite18.core.api.qna.service.QnaService;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.storage.db.core.qna.entity.Qna;
+import com.nerd.favorite18.storage.db.core.qna.projection.QnaListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+@Business
+public class QnaBusiness {
+    private final QnaService qnaService;
+
+    public Page<QnaListResponse> getMyQnaList(UserDto userDto, Pageable pageable) {
+
+        return qnaService.getMyQna(userDto, pageable);
+    }
+
+    public QnaDto getQna(UserDto userDto, Long id) {
+
+        return qnaService.getQna(userDto, id);
+    }
+
+    public Qna addQna(UserDto userDto, QnaAddRequest request) {
+
+        return qnaService.insertQna(userDto, request);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/controller/QnaController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/controller/QnaController.java
@@ -1,0 +1,44 @@
+package com.nerd.favorite18.core.api.qna.controller;
+
+import com.nerd.favorite18.core.api._common.annotation.UserSession;
+import com.nerd.favorite18.core.api._common.support.response.ApiResponse;
+import com.nerd.favorite18.core.api.qna.business.QnaBusiness;
+import com.nerd.favorite18.core.api.qna.dto.QnaAddRequest;
+import com.nerd.favorite18.core.api.qna.dto.QnaDto;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.storage.db.core.qna.entity.Qna;
+import com.nerd.favorite18.storage.db.core.qna.projection.QnaListResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/qna")
+@RestController
+public class QnaController {
+    private final QnaBusiness qnaBusiness;
+
+    @GetMapping
+    public ApiResponse<Page<QnaListResponse>> getMyQnaList(@UserSession UserDto userDto, Pageable pageable) {
+        Page<QnaListResponse> response = qnaBusiness.getMyQnaList(userDto, pageable);
+
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<QnaDto> getQna(@UserSession UserDto userDto, @PathVariable Long id) {
+        QnaDto response = qnaBusiness.getQna(userDto, id);
+
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping
+    public ApiResponse<Qna> addQna(@UserSession UserDto userDto, @RequestBody QnaAddRequest request) {
+        Qna response = qnaBusiness.addQna(userDto, request);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/converter/QnaConverter.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/converter/QnaConverter.java
@@ -1,0 +1,45 @@
+package com.nerd.favorite18.core.api.qna.converter;
+
+import com.nerd.favorite18.core.api._common.annotation.Converter;
+import com.nerd.favorite18.core.api._common.support.error.CoreApiException;
+import com.nerd.favorite18.core.api._common.support.error.ErrorType;
+import com.nerd.favorite18.core.api.qna.dto.QnaAddRequest;
+import com.nerd.favorite18.core.api.qna.dto.QnaDto;
+import com.nerd.favorite18.core.enums.qna.AnswerStatus;
+import com.nerd.favorite18.core.enums.qna.QnaProgressStatus;
+import com.nerd.favorite18.storage.db.core.qna.entity.Qna;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+
+import java.util.Optional;
+
+@Converter
+public class QnaConverter {
+    public Qna toEntity(User userEntity, QnaAddRequest request) {
+
+        return Optional.ofNullable(request)
+                .map(it -> Qna.builder()
+                        .qnaUser(userEntity)
+                        .title(request.getTitle())
+                        .content(request.getContent())
+                        .progressStatus(QnaProgressStatus.UNPROCESSED)
+                        .answerStatus(AnswerStatus.NO_REPLY)
+                        .build())
+                .orElseThrow(() -> new CoreApiException(ErrorType.NULL_POINT));
+    }
+
+    public QnaDto toDto(Qna entity) {
+
+        return QnaDto.of(
+                entity.getId(),
+                entity.getQnaUser(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getProgressStatus(),
+                entity.getAnswerStatus(),
+                entity.getAdminUser(),
+                entity.getAnswerContent(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/dto/QnaAddRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/dto/QnaAddRequest.java
@@ -1,0 +1,13 @@
+package com.nerd.favorite18.core.api.qna.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QnaAddRequest {
+    private String title;
+    private String content;
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/dto/QnaAddRequest.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/dto/QnaAddRequest.java
@@ -1,12 +1,8 @@
 package com.nerd.favorite18.core.api.qna.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
 public class QnaAddRequest {
     private String title;
     private String content;

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/dto/QnaDto.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/dto/QnaDto.java
@@ -1,0 +1,52 @@
+package com.nerd.favorite18.core.api.qna.dto;
+
+import com.nerd.favorite18.core.enums.qna.AnswerStatus;
+import com.nerd.favorite18.core.enums.qna.QnaProgressStatus;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QnaDto {
+    private Long id;
+    private User qnaUser;
+    private String title;
+    private String content;
+    private QnaProgressStatus progressStatus;
+    private AnswerStatus answerStatus;
+    private User adminUser;
+    private String answerContent;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static QnaDto of(
+            Long id,
+            User qnaUser,
+            String title,
+            String content,
+            QnaProgressStatus progressStatus,
+            AnswerStatus answerStatus,
+            User adminUser,
+            String answerContent,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new QnaDto(
+                id,
+                qnaUser,
+                title,
+                content,
+                progressStatus,
+                answerStatus,
+                adminUser,
+                answerContent,
+                createdAt,
+                updatedAt
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/service/QnaService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/service/QnaService.java
@@ -18,8 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -30,9 +28,8 @@ public class QnaService {
     private final UserRepository userRepository;
 
     public Page<QnaListResponse> getMyQna(UserDto userDto, Pageable pageable) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         final Page<QnaListResponse> qnas = qnaRepository.findAllByQnaUserOrderByCreatedAtDesc(userEntity, pageable);
         if (qnas == null) throw new CoreApiException(ErrorType.NULL_POINT);
@@ -41,9 +38,8 @@ public class QnaService {
     }
 
     public QnaDto getQna(UserDto userDto, Long id) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         Qna qnaEntity =  qnaRepository.findByIdAndQnaUserOrderByIdDesc(id, userEntity)
                 .orElseThrow(() -> new CoreApiException(ErrorType.NULL_POINT));
@@ -52,9 +48,8 @@ public class QnaService {
     }
 
     public Qna insertQna(UserDto userDto, QnaAddRequest request) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         Qna qnaEntity = qnaConverter.toEntity(userEntity, request);
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/service/QnaService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/service/QnaService.java
@@ -34,7 +34,10 @@ public class QnaService {
                 userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
         ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
-        return qnaRepository.findAllByQnaUserOrderByCreatedAtDesc(userEntity, pageable);
+        final Page<QnaListResponse> qnas = qnaRepository.findAllByQnaUserOrderByCreatedAtDesc(userEntity, pageable);
+        if (qnas == null) throw new CoreApiException(ErrorType.NULL_POINT);
+
+        return qnas;
     }
 
     public QnaDto getQna(UserDto userDto, Long id) {
@@ -42,7 +45,8 @@ public class QnaService {
                 userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
         ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
-        Qna qnaEntity =  qnaRepository.findByIdAndQnaUserOrderByIdDesc(id, userEntity);
+        Qna qnaEntity =  qnaRepository.findByIdAndQnaUserOrderByIdDesc(id, userEntity)
+                .orElseThrow(() -> new CoreApiException(ErrorType.NULL_POINT));
 
         return qnaConverter.toDto(qnaEntity);
     }

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/service/QnaService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/qna/service/QnaService.java
@@ -1,0 +1,59 @@
+package com.nerd.favorite18.core.api.qna.service;
+
+import com.nerd.favorite18.core.api._common.support.error.CoreApiException;
+import com.nerd.favorite18.core.api._common.support.error.ErrorType;
+import com.nerd.favorite18.core.api.qna.converter.QnaConverter;
+import com.nerd.favorite18.core.api.qna.dto.QnaAddRequest;
+import com.nerd.favorite18.core.api.qna.dto.QnaDto;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.enums.user.UserStatus;
+import com.nerd.favorite18.storage.db.core.qna.entity.Qna;
+import com.nerd.favorite18.storage.db.core.qna.projection.QnaListResponse;
+import com.nerd.favorite18.storage.db.core.qna.repository.QnaRepository;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import com.nerd.favorite18.storage.db.core.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class QnaService {
+    private final QnaRepository qnaRepository;
+    private final QnaConverter qnaConverter;
+
+    private final UserRepository userRepository;
+
+    public Page<QnaListResponse> getMyQna(UserDto userDto, Pageable pageable) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        return qnaRepository.findAllByQnaUserOrderByCreatedAtDesc(userEntity, pageable);
+    }
+
+    public QnaDto getQna(UserDto userDto, Long id) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        Qna qnaEntity =  qnaRepository.findByIdAndQnaUserOrderByIdDesc(id, userEntity);
+
+        return qnaConverter.toDto(qnaEntity);
+    }
+
+    public Qna insertQna(UserDto userDto, QnaAddRequest request) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        Qna qnaEntity = qnaConverter.toEntity(userEntity, request);
+
+        return qnaRepository.save(qnaEntity);
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/BaseEntity.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/BaseEntity.java
@@ -1,11 +1,9 @@
 package com.nerd.favorite18.storage.db.core;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-
 import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -20,11 +18,11 @@ public abstract class BaseEntity {
     private Long id;
 
     @CreationTimestamp
-    @Column @Comment("생성 일자")
+    @Comment("생성 일자")
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
-    @Column @Comment("수정 일자")
+    @Comment("수정 일자")
     private LocalDateTime updatedAt;
 
     public Long getId() {

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/BaseEntity.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/BaseEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 
+import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -19,11 +20,11 @@ public abstract class BaseEntity {
     private Long id;
 
     @CreationTimestamp
-    @Column
+    @Column @Comment("생성 일자")
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
-    @Column
+    @Column @Comment("수정 일자")
     private LocalDateTime updatedAt;
 
     public Long getId() {

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/BaseProjection.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/BaseProjection.java
@@ -1,0 +1,9 @@
+package com.nerd.favorite18.storage.db.core;
+
+import java.time.LocalDateTime;
+
+public interface BaseProjection {
+    Long getId();
+    LocalDateTime getCreatedAt();
+    LocalDateTime getUpdatedAt();
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/entity/Qna.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/entity/Qna.java
@@ -7,6 +7,7 @@ import com.nerd.favorite18.storage.db.core.user.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.Comment;
 
 @Entity
 @Table(name = "tbl_qna")
@@ -14,30 +15,39 @@ import lombok.*;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Qna extends BaseEntity {
+    @Comment("문의자 ID")
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "QNA_USER_ID")
+    @ManyToOne(fetch = FetchType.LAZY)
     private User qnaUser;
 
+    @Comment("문의 제목")
     @Column(length = 100, nullable = false)
     private String title;
 
-    @NotNull
+    @Comment("문의 내용")
+    @Column(nullable = false)
     @Lob
     private String content;
 
-    @NotNull
+    @Comment("진행 상태 : UNPROCESSED, IN_PROGRESS, ON_HOLD, COMPLETED")
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private QnaProgressStatus progressStatus;
 
-    @NotNull
+
+    @Comment("답변 상태 : NO_REPLY, REPLIED")
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private AnswerStatus answerStatus;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @Comment("답변자 ID")
     @JoinColumn(name = "ADMIN_USER_ID")
+    @ManyToOne(fetch = FetchType.LAZY)
     private User adminUser;
 
+    @Comment("답변 내용")
+    @Column
     @Lob
     private String answerContent;
 

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/entity/Qna.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/entity/Qna.java
@@ -1,0 +1,62 @@
+package com.nerd.favorite18.storage.db.core.qna.entity;
+
+import com.nerd.favorite18.core.enums.qna.AnswerStatus;
+import com.nerd.favorite18.core.enums.qna.QnaProgressStatus;
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(name = "tbl_qna")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Qna extends BaseEntity {
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "QNA_USER_ID")
+    private User qnaUser;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @NotNull
+    @Lob
+    private String content;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private QnaProgressStatus progressStatus;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AnswerStatus answerStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ADMIN_USER_ID")
+    private User adminUser;
+
+    @Lob
+    private String answerContent;
+
+    @Builder
+    public Qna(
+            User qnaUser,
+            String title,
+            String content,
+            QnaProgressStatus progressStatus,
+            AnswerStatus answerStatus,
+            User adminUser,
+            String answerContent
+    ) {
+        this.qnaUser = qnaUser;
+        this.title = title;
+        this.content = content;
+        this.progressStatus = progressStatus;
+        this.answerStatus = answerStatus;
+        this.adminUser = adminUser;
+        this.answerContent = answerContent;
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/projection/QnaListResponse.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/projection/QnaListResponse.java
@@ -2,14 +2,10 @@ package com.nerd.favorite18.storage.db.core.qna.projection;
 
 import com.nerd.favorite18.core.enums.qna.AnswerStatus;
 import com.nerd.favorite18.core.enums.qna.QnaProgressStatus;
+import com.nerd.favorite18.storage.db.core.BaseProjection;
 
-import java.time.LocalDateTime;
-
-public interface QnaListResponse {
-    Long getId();
+public interface QnaListResponse extends BaseProjection {
     String getTitle();
     QnaProgressStatus getProgressStatus();
     AnswerStatus getAnswerStatus();
-    LocalDateTime getCreatedAt();
-    LocalDateTime getUpdatedAt();
 }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/projection/QnaListResponse.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/projection/QnaListResponse.java
@@ -1,0 +1,15 @@
+package com.nerd.favorite18.storage.db.core.qna.projection;
+
+import com.nerd.favorite18.core.enums.qna.AnswerStatus;
+import com.nerd.favorite18.core.enums.qna.QnaProgressStatus;
+
+import java.time.LocalDateTime;
+
+public interface QnaListResponse {
+    Long getId();
+    String getTitle();
+    QnaProgressStatus getProgressStatus();
+    AnswerStatus getAnswerStatus();
+    LocalDateTime getCreatedAt();
+    LocalDateTime getUpdatedAt();
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/repository/QnaRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/repository/QnaRepository.java
@@ -7,8 +7,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface QnaRepository extends JpaRepository<Qna, Long> {
     Page<QnaListResponse> findAllByQnaUserOrderByCreatedAtDesc(User qnaUser, Pageable pageable);
-    Qna findByIdAndQnaUserOrderByIdDesc(Long id, User qnaUser);
+    Optional<Qna> findByIdAndQnaUserOrderByIdDesc(Long id, User qnaUser);
 }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/repository/QnaRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/qna/repository/QnaRepository.java
@@ -1,0 +1,14 @@
+package com.nerd.favorite18.storage.db.core.qna.repository;
+
+import com.nerd.favorite18.storage.db.core.qna.entity.Qna;
+import com.nerd.favorite18.storage.db.core.qna.projection.QnaListResponse;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface QnaRepository extends JpaRepository<Qna, Long> {
+    Page<QnaListResponse> findAllByQnaUserOrderByCreatedAtDesc(User qnaUser, Pageable pageable);
+    Qna findByIdAndQnaUserOrderByIdDesc(Long id, User qnaUser);
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
@@ -4,7 +4,9 @@ import com.nerd.favorite18.core.enums.user.UserStatus;
 import com.nerd.favorite18.storage.db.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository  extends JpaRepository<User, Long> {
-    User findBySubIdAndEmailAndStatusOrderByIdDesc(String subId, String email, UserStatus status);
-    User findFirstByIdAndStatusOrderByIdDesc(Long userId, UserStatus status);
+    Optional<User> findBySubIdAndEmailAndStatusOrderByIdDesc(String subId, String email, UserStatus status);
+    Optional<User> findFirstByIdAndStatusOrderByIdDesc(Long userId, UserStatus status);
 }


### PR DESCRIPTION
## 📝 PR Summary

Q&A 도메인을 추가하고 사용자 측 기능을 구현 완료 했습니다.
자세한 개발 내용은 아래와 같습니다.

- `Qna` 도메인이 추가되었습니다. 유저와 관리자 아이디를 `User` 도메인과 각각 N:1 단방향 맵핑 하도록 하였습니다.
- Q&A의 사용자측 기능인 내 Q&A 목록 조회, Q&A 세부내용 조회, Q&A 등록이 추가되었습니다.
   - Q&A 목록 조회 : 프로젝션을 이용하여 필요한 정보만 취득하고 페이징처리 하도록 구현했습니다.
   - Q&A 세부조회 : 우선 Q&A 전체 내용을 응답 받도록 구현했습니다.
   - Q&A 등록 : title, content 를 전달 받으면 새로운 Qna 가 등록됩니다.

#### 🌲 Working Branch

feat/#16-qna-client

#### 🌲 TODOs

- [x] Q&A 추가
- [x] 내 Q&A 목록 조회
- [x] Q&A 세부 조회

### Related Issues

resolve #16 

