### PR TITLE
[FEATURE] 회원탈퇴 기능 구현

### DIFF
--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/resolver/UserSessionResolver.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/_common/resolver/UserSessionResolver.java
@@ -44,7 +44,7 @@ public class UserSessionResolver implements HandlerMethodArgumentResolver {
         final Object userId = requestContext.getAttribute("userId", RequestAttributes.SCOPE_REQUEST);
 
         if (userId == null) throw new CoreApiException(ErrorType.DEFAULT_ERROR);
-        final UserDto userDto = userService.getUserWithThrow(Long.parseLong(userId.toString()));
+        final UserDto userDto = userService.getUserActiveWithThrow(Long.parseLong(userId.toString()));
 
         // 사용자 정보 세팅
         return userDto;

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/business/AuthBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/auth/business/AuthBusiness.java
@@ -59,7 +59,8 @@ public class AuthBusiness {
         // 구글 유저 정보 기반으로 유저를 조회
         UserDto userDto;
         try {
-            userDto = userService.getUserWithThrow(googleUserInfo.getSubId(), googleUserInfo.getEmail());
+            // 유저 조회하고 있으면 바로 반환, 만약 유저 상태가 ACTIVE 가 아니면 ACTIVE 로 바꾸고 사용자 반환
+            userDto = userService.getUserAndUpdateStatusWithThrow(googleUserInfo.getSubId(), googleUserInfo.getEmail());
         } catch (RuntimeException e) {
             // 조회되지 않으면 강제 회원가입 후 유저 반환
             userDto = userService.saveUser(UserRegisterRequest.of(

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/business/UserBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/business/UserBusiness.java
@@ -11,7 +11,24 @@ import lombok.RequiredArgsConstructor;
 public class UserBusiness {
     private final UserService userService;
 
+    /**
+     * [ 닉네임 수정 ]
+     *
+     * @param user 로그인 유저 정보
+     * @param request 업데이트할 이름
+     */
     public void updateNickname(UserDto user, UserUpdateNicknameRequest request) {
         userService.updateNickname(user, request);
+    }
+
+    /**
+     * [ 회원 탈퇴 ]
+     * <br/>
+     * 유저 정보를 삭제하지 않고, 상태만 DELETE 로 변경 <br/>
+     *
+     * @param user 로그인 유저 정보
+     */
+    public void deleteUser(UserDto user) {
+        userService.deleteUser(user);
     }
 }

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/controller/UserController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/controller/UserController.java
@@ -22,7 +22,7 @@ public class UserController {
     }
 
     // 사용자 닉네임 변경
-    @PutMapping("/set-nickname")
+    @PutMapping("/nickname")
     public ApiResponse<Void> updateNickname(@UserSession UserDto user, @RequestBody UserUpdateNicknameRequest request) {
         userBusiness.updateNickname(user, request);
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/controller/UserController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/controller/UserController.java
@@ -14,14 +14,25 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserBusiness userBusiness;
 
+    // 로그인 사용자 정보 확인
     @GetMapping("/me")
     public ApiResponse<UserDto> me(@UserSession UserDto user) {
+
         return ApiResponse.success(user);
     }
 
+    // 사용자 닉네임 변경
     @PutMapping("/set-nickname")
     public ApiResponse<Void> updateNickname(@UserSession UserDto user, @RequestBody UserUpdateNicknameRequest request) {
         userBusiness.updateNickname(user, request);
+
+        return ApiResponse.success();
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping
+    public ApiResponse<Void> deleteUser(@UserSession UserDto user) {
+        userBusiness.deleteUser(user);
 
         return ApiResponse.success();
     }

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/converter/UserConverter.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/converter/UserConverter.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 @Converter
 public class UserConverter {
     public User toEntity(UserRegisterRequest request) {
+
         return Optional.ofNullable(request)
                 .map(it -> User.builder()
                         .subId(request.getSubId())

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/service/UserService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/service/UserService.java
@@ -13,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @RequiredArgsConstructor
 @Service
 public class UserService {
@@ -31,11 +29,10 @@ public class UserService {
      */
     @Transactional
     public UserDto getUserAndUpdateStatusWithThrow(String subId, String email) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstBySubIdAndEmailOrderByIdDesc(subId, email)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstBySubIdAndEmailOrderByIdDesc(subId, email)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
-        if (userEntity.getStatus() != UserStatus.ACTIVE) {
+        if (userEntity.isUserStatusInactive()) {
             userEntity.updateStatus(UserStatus.ACTIVE);
 
             userEntity = userRepository.save(userEntity);
@@ -52,9 +49,8 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public UserDto getUserActiveWithThrow(Long userId) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstByIdAndStatusOrderByIdDesc(userId, UserStatus.ACTIVE)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstByIdAndStatusOrderByIdDesc(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         return userConverter.toDto(userEntity);
     }
@@ -82,9 +78,8 @@ public class UserService {
      */
     @Transactional
     public void updateNickname(UserDto user, UserUpdateNicknameRequest request) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstByIdAndStatusOrderByIdDesc(user.getId(), UserStatus.ACTIVE)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstByIdAndStatusOrderByIdDesc(user.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         userEntity.updateNickname(request.getNickname());
 
@@ -98,9 +93,8 @@ public class UserService {
      */
     @Transactional
     public void deleteUser(UserDto user) {
-        User userEntity = Optional.ofNullable(
-                userRepository.findFirstByIdAndStatusOrderByIdDesc(user.getId(), UserStatus.ACTIVE)
-        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+        User userEntity = userRepository.findFirstByIdAndStatusOrderByIdDesc(user.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         userEntity.updateStatus(UserStatus.DELETE);
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/service/UserService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/user/service/UserService.java
@@ -21,17 +21,37 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserConverter userConverter;
 
-    @Transactional(readOnly = true)
-    public UserDto getUserWithThrow(String subId, String email) {
+    /**
+     * 상태 관계없이 사용자 1명 조회 후
+     * 상태가 Active 가 아니면 Active 로 변경
+     *
+     * @param subId Oauth ID
+     * @param email 사용자 이메일
+     * @return 사용자 DTO
+     */
+    @Transactional
+    public UserDto getUserAndUpdateStatusWithThrow(String subId, String email) {
         User userEntity = Optional.ofNullable(
-                userRepository.findBySubIdAndEmailAndStatusOrderByIdDesc(subId, email, UserStatus.ACTIVE)
+                userRepository.findFirstBySubIdAndEmailOrderByIdDesc(subId, email)
         ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        if (userEntity.getStatus() != UserStatus.ACTIVE) {
+            userEntity.updateStatus(UserStatus.ACTIVE);
+
+            userEntity = userRepository.save(userEntity);
+        }
 
         return userConverter.toDto(userEntity);
     }
 
+    /**
+     * 사용자 ID 로 Active 상태 사용자 1명 조회
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 DTO
+     */
     @Transactional(readOnly = true)
-    public UserDto getUserWithThrow(Long userId) {
+    public UserDto getUserActiveWithThrow(Long userId) {
         User userEntity = Optional.ofNullable(
                 userRepository.findFirstByIdAndStatusOrderByIdDesc(userId, UserStatus.ACTIVE)
         ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
@@ -39,15 +59,27 @@ public class UserService {
         return userConverter.toDto(userEntity);
     }
 
+    /**
+     * 사용자 정보 저장
+     *
+     * @param request 사용자 가입 정보
+     * @return 사용자 DTO
+     */
     @Transactional
     public UserDto saveUser(UserRegisterRequest request) {
         final User userEntity = userConverter.toEntity(request);
 
-        final User newUserEntity = userRepository.save(userEntity);
+        final User saveEntity = userRepository.save(userEntity);
 
-        return userConverter.toDto(newUserEntity);
+        return userConverter.toDto(saveEntity);
     }
 
+    /**
+     * 사용자 조회 후 사용자 닉네임 업데이트하여 저장
+     *
+     * @param user 로그인 사용자 정보
+     * @param request 변경할 닉네임
+     */
     @Transactional
     public void updateNickname(UserDto user, UserUpdateNicknameRequest request) {
         User userEntity = Optional.ofNullable(
@@ -55,6 +87,22 @@ public class UserService {
         ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         userEntity.updateNickname(request.getNickname());
+
+        userRepository.save(userEntity);
+    }
+
+    /**
+     * ACTIVE 상태 사용자 조회하여 DELETE 로 변경 후 저장
+     *
+     * @param user 로그인 사용자 정보
+     */
+    @Transactional
+    public void deleteUser(UserDto user) {
+        User userEntity = Optional.ofNullable(
+                userRepository.findFirstByIdAndStatusOrderByIdDesc(user.getId(), UserStatus.ACTIVE)
+        ).orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        userEntity.updateStatus(UserStatus.DELETE);
 
         userRepository.save(userEntity);
     }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/entity/User.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/entity/User.java
@@ -90,4 +90,8 @@ public class User extends BaseEntity {
     public void updateStatus(UserStatus status) {
         this.status = status;
     }
+
+    public boolean isUserStatusInactive() {
+        return this.status != UserStatus.ACTIVE;
+    }
 }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/entity/User.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/entity/User.java
@@ -14,36 +14,49 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Comment;
 
 @Entity
 @Table(name = "tbl_user")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
+    @Comment("사용자 ID : provider_sub")
     @Column(length = 100, nullable = false)
     private String subId;
 
+    @Comment("사용자 이메일")
     @Column(length = 50, nullable = false)
     private String email;
 
+    @Comment("사용자 이름")
     @Column(length = 20)
     private String name;
 
+    @Comment("사용자 별명")
     @Column(length = 30)
     private String nickname;
 
-    @Column(length = 20)
+    @Comment("사용자 생일")
+    @Setter @Column(length = 20)
     private String birth;
 
+    @Comment("사용자 성별 : MAN, WOMEN")
+    @Setter @Column
     @Enumerated(EnumType.STRING)
     private UserGender gender;
 
+    @Comment("사용자 프로필 섬네일 링크")
+    @Column
     private String thumbnail;
 
+    @Comment("사용자 권한 : ADMIN, USER")
+    @Setter @Column
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    @Comment("사용자 활성상태 : NOT_ACTIVE, ACTIVE, SUSPENSION, DELETE")
+    @Column
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
@@ -72,5 +85,9 @@ public class User extends BaseEntity {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateStatus(UserStatus status) {
+        this.status = status;
     }
 }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
@@ -4,7 +4,9 @@ import com.nerd.favorite18.core.enums.user.UserStatus;
 import com.nerd.favorite18.storage.db.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository  extends JpaRepository<User, Long> {
-    User findFirstBySubIdAndEmailOrderByIdDesc(String subId, String email);
-    User findFirstByIdAndStatusOrderByIdDesc(Long userId, UserStatus status);
+    Optional<User> findFirstBySubIdAndEmailOrderByIdDesc(String subId, String email);
+    Optional<User> findFirstByIdAndStatusOrderByIdDesc(Long userId, UserStatus status);
 }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/user/repository/UserRepository.java
@@ -5,6 +5,6 @@ import com.nerd.favorite18.storage.db.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository  extends JpaRepository<User, Long> {
-    User findBySubIdAndEmailAndStatusOrderByIdDesc(String subId, String email, UserStatus status);
+    User findFirstBySubIdAndEmailOrderByIdDesc(String subId, String email);
     User findFirstByIdAndStatusOrderByIdDesc(Long userId, UserStatus status);
 }


### PR DESCRIPTION
## 📝 PR Summary

- 회원 탈퇴 로직이 추가되었습니다. ACTIVE 인 사용자 상태를 DELETE 로 변경합니다.
- `AuthBusiness` 회원 탈퇴 로직에 맞춰 사용자 로그인 로직이 수정되었습니다. 
> (기존) 로그인 시 ACTIVE 상태 사용자만 찾아서 반환 -> (변경) 모든 상태 사용자를 찾고 만약 탈퇴한 사용자이면 다시 활성화 상태로 변경
- `User` 도메인에도 코멘트 추가하였습니다. 불필요한 Setter 는 남발하지 않고 필요한 곳에만 어노테이션 하였습니다.

#### 🌲 Working Branch

feat/#9-user-delete

#### 🌲 TODOs

- [x] 회원 탈퇴 요청 시 회원 상태 변경
- [x] 탈퇴 후 재 가입 시 로직 구현 (`AuthBusiness` OAuth 로그인 로직 변경)

### Related Issues

resolve #9

### 📚 Remarks
이 외에도 회원 탈퇴 시 유저 정보를 언제까지 가지고 있을지, 
DELETE 에서 ACTIVE 로 변경한다면 따로 사용자에 알림이 필요한지,
정지 상태, 비활성 상태의 처리는 어떻게 할지 등 생각해볼 사항이 많이 있습니다만,
프로젝트 주제에서 많이 벗어나는 것 같아 우선 이 정도만 구현 하겠습니다.

다른 좋은 의견 있으시면 코멘트 주세요 :)

