### PR TITLE
[FEATURE] Entity 추가

### DIFF
--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/AnalysisScore.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/AnalysisScore.java
@@ -1,0 +1,77 @@
+package com.nerd.favorite18.storage.db.core.analysis.entity;
+
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import com.nerd.favorite18.storage.db.core.song.entity.Song;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Comment("노래방 점수 분석")
+@Entity
+@Table(name = "tbl_score")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnalysisScore extends BaseEntity {
+
+    @Comment("사용자 ID")
+    @NotNull
+    @JoinColumn(name = "USER_ID")
+    @OneToOne(fetch =  FetchType.LAZY)
+    private User requestAnalysisUser;
+
+    @Comment("노래 ID")
+    @NotNull
+    @JoinColumn(name = "SONG_ID")
+    @OneToOne(fetch =  FetchType.LAZY)
+    private Song requestAnalysisSong;
+
+    @Comment("녹음파일 경로")
+    @Column(name = "M4A_FILE_PATH", nullable = false)
+    private String m4aFilePath;
+
+    @Comment("분석점수")
+    @Column(name = "SCORE", nullable = false)
+    private Integer analysisScore;
+
+    @Builder
+    private AnalysisScore(
+        User requestAnalysisUser,
+        Song requestAnalysisSong,
+        String m4aFilePath,
+        Integer analysisScore
+    ) {
+        this.requestAnalysisUser = requestAnalysisUser;
+        this.requestAnalysisSong = requestAnalysisSong;
+        this.m4aFilePath = m4aFilePath;
+        this.analysisScore = analysisScore;
+    }
+
+    public static AnalysisScore of(User requestAnalysisUser, Song requestAnalysisSong, String m4aFilePath, Integer analysisScore) {
+        isValidScore(analysisScore);
+
+        return AnalysisScore.builder()
+            .requestAnalysisUser(requestAnalysisUser)
+            .requestAnalysisSong(requestAnalysisSong)
+            .m4aFilePath(m4aFilePath)
+            .analysisScore(analysisScore)
+            .build();
+    }
+
+    // 추후 상수화 필요성
+    private static void isValidScore(int score) {
+        if (score >= 0 && score <= 100) {
+            return;
+        }
+        throw new IllegalArgumentException("분석 점수가 정상 범주가 아닙니다.");
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/SuggestSong.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/SuggestSong.java
@@ -1,0 +1,61 @@
+package com.nerd.favorite18.storage.db.core.analysis.entity;
+
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import com.nerd.favorite18.storage.db.core.song.entity.Song;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Comment("대화를 통한 곡 추천")
+@Entity
+@Table(name = "tbl_suggest")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SuggestSong extends BaseEntity {
+
+    @Comment("사용자 ID")
+    @NotNull
+    @JoinColumn(name = "USER_ID")
+    @OneToOne(fetch =  FetchType.LAZY)
+    private User suggestUser;
+
+    @Comment("노래 ID")
+    @NotNull
+    @JoinColumn(name = "SUGGEST_SONG_ID")
+    @ManyToOne(fetch =  FetchType.LAZY)
+    private Song suggestSong;
+
+    @Comment("감정지수")
+    @Column(name = "EMOTION")
+    private String emotion;
+
+    // 대화내용
+    @OneToMany(mappedBy = "suggestSong", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SuggestSongConversation> conversations = new ArrayList<>();
+
+    @Builder
+    private SuggestSong(User suggestUser, Song suggestSong, String emotion) {
+        this.suggestUser = suggestUser;
+        this.suggestSong = suggestSong;
+        this.emotion = emotion;
+    }
+
+    public void addConversation(String conversation) {
+        conversations.add(SuggestSongConversation.of(this, conversation));
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/SuggestSongConversation.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/SuggestSongConversation.java
@@ -1,0 +1,43 @@
+package com.nerd.favorite18.storage.db.core.analysis.entity;
+
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Comment("곡추천 분석 대화 목록")
+@Entity
+@Table(name = "tbl_suggest_conversation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SuggestSongConversation extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private SuggestSong suggestSong;
+
+    @Comment("내화내용")
+    @Column(name = "CONVERSATION", nullable = false)
+    private String conversation;
+
+    @Builder
+    private SuggestSongConversation(SuggestSong suggestSong, String conversation) {
+        this.suggestSong = suggestSong;
+        this.conversation = conversation;
+    }
+
+    public static SuggestSongConversation of(
+        SuggestSong suggestSong, String conversation
+    ) {
+        return SuggestSongConversation.builder()
+            .suggestSong(suggestSong)
+            .conversation(conversation)
+            .build();
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/SuggestSongConversation.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/entity/SuggestSongConversation.java
@@ -22,7 +22,7 @@ public class SuggestSongConversation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private SuggestSong suggestSong;
 
-    @Comment("내화내용")
+    @Comment("대화내용")
     @Column(name = "CONVERSATION", nullable = false)
     private String conversation;
 

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/repository/AnalysisScoreRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/repository/AnalysisScoreRepository.java
@@ -1,0 +1,8 @@
+package com.nerd.favorite18.storage.db.core.analysis.repository;
+
+import com.nerd.favorite18.storage.db.core.analysis.entity.AnalysisScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnalysisScoreRepository extends JpaRepository<AnalysisScore, Long> {
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/repository/SuggestSonConversationRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/repository/SuggestSonConversationRepository.java
@@ -1,0 +1,8 @@
+package com.nerd.favorite18.storage.db.core.analysis.repository;
+
+import com.nerd.favorite18.storage.db.core.analysis.entity.SuggestSongConversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SuggestSonConversationRepository extends JpaRepository<SuggestSongConversation, Long> {
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/repository/SuggestSongRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/analysis/repository/SuggestSongRepository.java
@@ -1,0 +1,8 @@
+package com.nerd.favorite18.storage.db.core.analysis.repository;
+
+import com.nerd.favorite18.storage.db.core.analysis.entity.SuggestSong;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SuggestSongRepository extends JpaRepository<SuggestSong, Long> {
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/map/entity/SurroundingKaraoke.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/map/entity/SurroundingKaraoke.java
@@ -1,0 +1,77 @@
+package com.nerd.favorite18.storage.db.core.map.entity;
+
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 노래방의 정보를 담는 테이블
+ */
+
+@Comment("노래방 정보")
+@Entity
+@Table(name = "tbl_surrounding")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SurroundingKaraoke extends BaseEntity {
+
+    @Comment("상호명")
+    @Column(name = "COMPANY_NAME", nullable = false)
+    private String companyName;
+
+    // 테이블 제작자에게 의견 확인 필요.
+    @Comment("주소")
+    @Column(name = "ADDRESS", nullable = false)
+    private Long address;
+
+    // 테이블 제작자에게 의견 확인 필요.
+    @Comment("위도")
+    @Column(name = "LATITUDE", nullable = false)
+    private Long latitude;
+
+    // 테이블 제작자에게 의견 확인 필요.
+    @Comment("경도")
+    @Column(name = "LONGITUTE", nullable = false)
+    private Long longitute;
+
+    // 테이블 제작자에게 의견 확인 필요.
+    @Comment("거리")
+    @Column(name = "DISTANCE", nullable = false)
+    private String distance;
+
+    // 테이블 제작자에게 의견 확인 필요.
+    @Comment("오픈시간")
+    @Column(name = "OPENING", nullable = false)
+    private LocalDateTime opening;
+
+    // 테이블 제작자에게 의견 확인 필요.
+    @Comment("종료시간")
+    @Column(name = "CLOSING", nullable = false)
+    private LocalDateTime closing;
+
+    @Builder
+    private SurroundingKaraoke(
+        String companyName,
+        Long address,
+        Long latitude,
+        Long longitute,
+        String distance,
+        LocalDateTime opening,
+        LocalDateTime closing
+    ) {
+        this.companyName = companyName;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitute = longitute;
+        this.distance = distance;
+        this.opening = opening;
+        this.closing = closing;
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/map/repository/SurroundingKaraoKeRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/map/repository/SurroundingKaraoKeRepository.java
@@ -1,0 +1,8 @@
+package com.nerd.favorite18.storage.db.core.map.repository;
+
+import com.nerd.favorite18.storage.db.core.map.entity.SurroundingKaraoke;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SurroundingKaraoKeRepository extends JpaRepository<SurroundingKaraoke, Long> {
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/Song.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/Song.java
@@ -1,0 +1,101 @@
+package com.nerd.favorite18.storage.db.core.song.entity;
+
+import com.nerd.favorite18.core.enums.song.MachineType;
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Comment("노래 정보")
+@Entity
+@Table(name = "tbl_song")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Song extends BaseEntity {
+
+    @Comment("노래 제목")
+    @Column(name = "TITLE", nullable = false)
+    private String title;
+
+    @Comment("노래 가수 명")
+    @Column(name = "ARTIST", nullable = false)
+    private String artist;
+
+    @Comment("앨범 이미지")
+    @Column(name = "ALBUM_PIC_URL")
+    private String albumPictureUrl;
+
+    @Comment("노래 가사")
+    @Column(name = "LYLICS")
+    @Lob
+    private String lylics;
+
+    @Comment("점수 비교가 가능한 파일 경로")
+    @Column(name = "SCORE_COMPARE_URL")
+    private String scoreCompareUrl;
+
+    @Comment("공백을 전부 제거한 제목이 들어가며, "
+        + "회사별로 다르게 등록된 노래 제목을 확인하기 위해 사용")
+    @Column(name = "COMPARE_TITLE", nullable = false)
+    private String compareTitle;
+
+    /**
+     * SongCode는 Song에만 의존하기 때문에 orphanRemoval가 상관이 없음.
+     */
+    @OneToMany(mappedBy = "song", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SongCode> songCodes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "song", fetch = FetchType.LAZY)
+    private List<SongLike> songLikes = new ArrayList<>();
+
+    @Builder
+    private Song(
+        String title,
+        String artist,
+        String albumPictureUrl,
+        String lylics,
+        String scoreCompareUrl,
+        String compareTitle
+    ) {
+        this.title = title;
+        this.artist = artist;
+        this.albumPictureUrl = albumPictureUrl;
+        this.lylics = lylics;
+        this.scoreCompareUrl = scoreCompareUrl;
+        this.compareTitle = compareTitle;
+    }
+
+    public void addSongCode(SongCode songCode) {
+        songCode.setSong(this);
+        songCodes.add(songCode);
+    }
+
+    public void addSongCode(MachineType machineType, String songNum) {
+        this.addSongCode(SongCode.of(machineType, songNum));
+    }
+
+    /** 크롤링시, TJ, KY에 등록된 노래가 이미 등록되어 있는지 확인하기 위함 */
+    public boolean isEqualsSongTitle(String diffTitle) {
+        diffTitle = diffTitle.replaceAll(" ", "");
+        diffTitle = diffTitle.trim();
+
+        return compareTitle.equalsIgnoreCase(diffTitle);
+    }
+
+    /** 노래가 좋아요를 받은 총 갯수.  */
+    public int getTotalLikeCnt() {
+        return this.songLikes.size();
+    }
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/SongCode.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/SongCode.java
@@ -1,0 +1,55 @@
+package com.nerd.favorite18.storage.db.core.song.entity;
+
+import com.nerd.favorite18.core.enums.song.MachineType;
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Comment;
+
+@Comment("노래 정보")
+@Entity
+@Table(name = "tbl_song_code")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SongCode extends BaseEntity {
+
+    @Setter
+    @Comment("곡정보 ID")
+    @JoinColumn(name = "SONG_ID", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Song song;
+
+    @Comment("노래방 기기 종류 : TJ(TJ), KY(금영)")
+    @Column(name = "MACHINE_TYPE", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MachineType machineType;
+
+    @Comment("노래 곡 번호")
+    @Column(name = "SONG_NUM", nullable = false)
+    private String songNum;
+
+    @Builder
+    private SongCode(Song song, MachineType machineType, String songNum) {
+        this.song = song;
+        this.machineType = machineType;
+        this.songNum = songNum;
+    }
+
+    public static SongCode of(MachineType machineType, String songNum) {
+        return SongCode.builder()
+            .machineType(machineType)
+            .songNum(songNum)
+            .build();
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/SongLike.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/SongLike.java
@@ -1,0 +1,49 @@
+package com.nerd.favorite18.storage.db.core.song.entity;
+
+import com.nerd.favorite18.storage.db.core.BaseEntity;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Comment("사용자의 노래 좋아요")
+@Entity
+@Table(name = "tbl_song_like")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SongLike extends BaseEntity {
+
+    @Comment("사용자 ID")
+    @NotNull
+    @JoinColumn(name = "USER_ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User songLikeUser;
+
+    @Comment("노래 ID")
+    @NotNull
+    @JoinColumn(name = "SONG_ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Song song;
+
+
+    @Builder
+    private SongLike(User songLikeUser, Song song) {
+        this.songLikeUser = songLikeUser;
+        this.song = song;
+    }
+
+    public static SongLike of(User user, Song song) {
+        return SongLike.builder()
+            .songLikeUser(user)
+            .song(song)
+            .build();
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongCodeRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongCodeRepository.java
@@ -1,0 +1,9 @@
+package com.nerd.favorite18.storage.db.core.song.repository;
+
+
+import com.nerd.favorite18.storage.db.core.song.entity.SongCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongCodeRepository extends JpaRepository<SongCode, Long> {
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongLikeRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongLikeRepository.java
@@ -1,0 +1,8 @@
+package com.nerd.favorite18.storage.db.core.song.repository;
+
+import com.nerd.favorite18.storage.db.core.song.entity.SongLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongLikeRepository extends JpaRepository<SongLike, Long> {
+
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongRepository.java
@@ -1,0 +1,9 @@
+package com.nerd.favorite18.storage.db.core.song.repository;
+
+
+import com.nerd.favorite18.storage.db.core.song.entity.Song;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongRepository extends JpaRepository<Song, Long> {
+
+}


### PR DESCRIPTION
## 📝 PR Summary
Table로 구성한 내용을 Entity로 사전에 제작하였습니다.(개발 편의를 위해서)

#### 🌲 Working Branch

- feat/#21

#### 🌲 TODOs

- [x] 좋아요
- [x] 노래 정보
- [x] 노래 추가여부 확인 테이블 (노래정보, TBL_SONG에 그냥 컬럼추가함.)
- [x] 기기별 노래방 번호
- [x] 주변검색 테이블
- [x] 랭킹 (서영님이 이미 로컬브랜치에서 구현)
- [x] 분석 - 점수
- [x] 분석 - 곡추천

### Related Issues

- 주변검색 테이블(노래방정보) 컬럼들 의미 한번 진현님한테 회의때 확인 필요함.
- 점수와 곡 추천은 먼저 '제작' 만 진행함.
    - 곡추천시 대화목록에 대해서, 테이블로 구상이 필요한것인지 확인 필요, 일단 테이블로 따로 뺴둠. 
