### PR TITLE
[FEATURE] 즐겨찾기 기능 구현

### DIFF
--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/business/SongLikeBusiness.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/business/SongLikeBusiness.java
@@ -1,0 +1,27 @@
+package com.nerd.favorite18.core.api.song.business;
+
+import com.nerd.favorite18.core.api._common.annotation.Business;
+import com.nerd.favorite18.core.api.song.dto.SongLikeDto;
+import com.nerd.favorite18.core.api.song.service.SongLikeService;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+@Business
+public class SongLikeBusiness {
+    private final SongLikeService songLikeService;
+
+    public Page<SongLikeDto> myLikeList(UserDto userDto, Pageable pageable) {
+        return songLikeService.getMySongLikeList(userDto, pageable);
+    }
+
+    public void like(UserDto userDto, Long songId) {
+        songLikeService.insertSongLike(userDto, songId);
+    }
+
+    public void unLike(UserDto userDto, Long songId) {
+        songLikeService.deleteSongLike(userDto, songId);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/controller/SongLikeController.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/controller/SongLikeController.java
@@ -1,0 +1,39 @@
+package com.nerd.favorite18.core.api.song.controller;
+
+import com.nerd.favorite18.core.api._common.annotation.UserSession;
+import com.nerd.favorite18.core.api._common.support.response.ApiResponse;
+import com.nerd.favorite18.core.api.song.business.SongLikeBusiness;
+import com.nerd.favorite18.core.api.song.dto.SongLikeDto;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/like")
+@RestController
+public class SongLikeController {
+    private final SongLikeBusiness songLikeBusiness;
+
+    @GetMapping
+    public ApiResponse<Page<SongLikeDto>> myLikeList(@UserSession UserDto userDto, Pageable pageable) {
+        final Page<SongLikeDto> response = songLikeBusiness.myLikeList(userDto, pageable);
+
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/{id}")
+    public ApiResponse<Void> like(@UserSession UserDto userDto, @PathVariable Long id) {
+        songLikeBusiness.like(userDto, id);
+
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> unLike(@UserSession UserDto userDto, @PathVariable Long id) {
+        songLikeBusiness.unLike(userDto, id);
+
+        return ApiResponse.success();
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/converter/SongLikeConverter.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/converter/SongLikeConverter.java
@@ -1,0 +1,32 @@
+package com.nerd.favorite18.core.api.song.converter;
+
+import com.nerd.favorite18.core.api._common.annotation.Converter;
+import com.nerd.favorite18.core.api.song.dto.SongDto;
+import com.nerd.favorite18.core.api.song.dto.SongLikeDto;
+import com.nerd.favorite18.storage.db.core.song.entity.Song;
+import com.nerd.favorite18.storage.db.core.song.entity.SongLike;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Converter
+public class SongLikeConverter {
+    public SongLike toEntity(User userEntity, Song songEntity) {
+
+        return SongLike.builder()
+                .songLikeUser(userEntity)
+                .song(songEntity)
+                .build();
+    }
+
+    // TODO : Song 서비스 통합 후 songEntity 를 songDto 로 변경 해야함
+    public SongLikeDto toDto(SongLike entity, SongDto songDto) {
+
+        return SongLikeDto.of(
+                entity.getId(),
+                songDto,
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/dto/SongDto.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/dto/SongDto.java
@@ -1,0 +1,19 @@
+package com.nerd.favorite18.core.api.song.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SongDto {
+    private Long id;
+    private String title;
+    private String artist;
+    private String albumPictureUrl;
+
+    public static SongDto of(Long id, String title, String artist, String albumPictureUrl) {
+        return new SongDto(id, title, artist, albumPictureUrl);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/dto/SongLikeDto.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/dto/SongLikeDto.java
@@ -1,0 +1,21 @@
+package com.nerd.favorite18.core.api.song.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SongLikeDto {
+    private Long id;
+    private SongDto song;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static SongLikeDto of(Long id, SongDto song, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new SongLikeDto(id, song, createdAt, updatedAt);
+    }
+}

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/service/SongLikeService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/service/SongLikeService.java
@@ -10,6 +10,7 @@ import com.nerd.favorite18.core.enums.user.UserStatus;
 import com.nerd.favorite18.storage.db.core.song.projection.SongLikeProjection;
 import com.nerd.favorite18.storage.db.core.song.entity.Song;
 import com.nerd.favorite18.storage.db.core.song.entity.SongLike;
+import com.nerd.favorite18.storage.db.core.song.projection.SongProjection;
 import com.nerd.favorite18.storage.db.core.song.repository.SongLikeRepository;
 import com.nerd.favorite18.storage.db.core.song.repository.SongRepository;
 import com.nerd.favorite18.storage.db.core.user.entity.User;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 
 @RequiredArgsConstructor
 @Service
@@ -35,13 +37,20 @@ public class SongLikeService {
                 .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
 
         final Page<SongLikeProjection> projections = songLikeRepository.findAllBySongLikeUserOrderByCreatedAtDesc(userEntity, pageable);
-        if (projections == null) throw new CoreApiException(ErrorType.NULL_POINT);
 
-        return projections.map(it -> SongLikeDto.of(
-                it.getId(),
-                SongDto.of(it.getSong().getId(), it.getSong().getTitle(), it.getSong().getArtist(), it.getSong().getAlbumPictureUrl()),
-                it.getCreatedAt(),
-                it.getUpdatedAt())
+        if (ObjectUtils.isEmpty(projections)) {
+            throw new CoreApiException(ErrorType.NULL_POINT);
+        }
+
+        return projections.map(page -> {
+                SongProjection song = page.getSong();
+                
+                return SongLikeDto.of(
+                    page.getId(),
+                    SongDto.of(song.getId(), song.getTitle(), song.getArtist(), song.getAlbumPictureUrl()),
+                    page.getCreatedAt(),
+                    page.getUpdatedAt());
+            }
         );
     }
 

--- a/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/service/SongLikeService.java
+++ b/core/core-api/src/main/java/com/nerd/favorite18/core/api/song/service/SongLikeService.java
@@ -1,0 +1,73 @@
+package com.nerd.favorite18.core.api.song.service;
+
+import com.nerd.favorite18.core.api._common.support.error.CoreApiException;
+import com.nerd.favorite18.core.api._common.support.error.ErrorType;
+import com.nerd.favorite18.core.api.song.converter.SongLikeConverter;
+import com.nerd.favorite18.core.api.song.dto.SongDto;
+import com.nerd.favorite18.core.api.song.dto.SongLikeDto;
+import com.nerd.favorite18.core.api.user.dto.UserDto;
+import com.nerd.favorite18.core.enums.user.UserStatus;
+import com.nerd.favorite18.storage.db.core.song.projection.SongLikeProjection;
+import com.nerd.favorite18.storage.db.core.song.entity.Song;
+import com.nerd.favorite18.storage.db.core.song.entity.SongLike;
+import com.nerd.favorite18.storage.db.core.song.repository.SongLikeRepository;
+import com.nerd.favorite18.storage.db.core.song.repository.SongRepository;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import com.nerd.favorite18.storage.db.core.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class SongLikeService {
+    private final SongLikeRepository songLikeRepository;
+    private final SongLikeConverter songLikeConverter;
+
+    private final UserRepository userRepository;
+    private final SongRepository songRepository;
+
+    @Transactional(readOnly = true)
+    public Page<SongLikeDto> getMySongLikeList(UserDto userDto, Pageable pageable) {
+        User userEntity =  userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        final Page<SongLikeProjection> projections = songLikeRepository.findAllBySongLikeUserOrderByCreatedAtDesc(userEntity, pageable);
+        if (projections == null) throw new CoreApiException(ErrorType.NULL_POINT);
+
+        return projections.map(it -> SongLikeDto.of(
+                it.getId(),
+                SongDto.of(it.getSong().getId(), it.getSong().getTitle(), it.getSong().getArtist(), it.getSong().getAlbumPictureUrl()),
+                it.getCreatedAt(),
+                it.getUpdatedAt())
+        );
+    }
+
+    @Transactional
+    public void insertSongLike(UserDto userDto, Long songId) {
+        User userEntity =  userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        Song songEntity = songRepository.findFirstByIdOrderByIdDesc(songId)
+                // TODO : Song 서비스 통합 후 에러 변경 해야함
+                .orElseThrow(() -> new CoreApiException(ErrorType.DEFAULT_ERROR));
+
+        SongLike songLikeEntity = songLikeConverter.toEntity(userEntity, songEntity);
+
+        songLikeRepository.save(songLikeEntity);
+    }
+
+    @Transactional
+    public void deleteSongLike(UserDto userDto, Long songId) {
+        User userEntity =  userRepository.findFirstByIdAndStatusOrderByIdDesc(userDto.getId(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CoreApiException(ErrorType.USER_NOT_FOUND));
+
+        Song songEntity = songRepository.findFirstByIdOrderByIdDesc(songId)
+                // TODO : Song 서비스 통합 후 에러 변경 해야함
+                .orElseThrow(() -> new CoreApiException(ErrorType.DEFAULT_ERROR));
+
+        songLikeRepository.deleteBySongLikeUserAndSong(userEntity, songEntity);
+    }
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/SongLike.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/entity/SongLike.java
@@ -2,11 +2,7 @@ package com.nerd.favorite18.storage.db.core.song.entity;
 
 import com.nerd.favorite18.storage.db.core.BaseEntity;
 import com.nerd.favorite18.storage.db.core.user.entity.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +12,12 @@ import org.hibernate.annotations.Comment;
 
 @Comment("사용자의 노래 좋아요")
 @Entity
-@Table(name = "tbl_song_like")
+@Table(
+        name = "SONG_LIKE",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"USER_ID", "SONG_ID"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SongLike extends BaseEntity {
@@ -41,6 +42,7 @@ public class SongLike extends BaseEntity {
     }
 
     public static SongLike of(User user, Song song) {
+
         return SongLike.builder()
             .songLikeUser(user)
             .song(song)

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/projection/SongLikeProjection.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/projection/SongLikeProjection.java
@@ -1,0 +1,7 @@
+package com.nerd.favorite18.storage.db.core.song.projection;
+
+import com.nerd.favorite18.storage.db.core.BaseProjection;
+
+public interface SongLikeProjection extends BaseProjection {
+    SongProjection getSong();
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/projection/SongProjection.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/projection/SongProjection.java
@@ -1,0 +1,10 @@
+package com.nerd.favorite18.storage.db.core.song.projection;
+
+import com.nerd.favorite18.storage.db.core.BaseProjection;
+
+public interface SongProjection extends BaseProjection {
+    Long getId();
+    String getTitle();
+    String getArtist();
+    String getAlbumPictureUrl();
+}

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongLikeRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongLikeRepository.java
@@ -1,8 +1,14 @@
 package com.nerd.favorite18.storage.db.core.song.repository;
 
+import com.nerd.favorite18.storage.db.core.song.projection.SongLikeProjection;
+import com.nerd.favorite18.storage.db.core.song.entity.Song;
 import com.nerd.favorite18.storage.db.core.song.entity.SongLike;
+import com.nerd.favorite18.storage.db.core.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SongLikeRepository extends JpaRepository<SongLike, Long> {
-
+    Page<SongLikeProjection> findAllBySongLikeUserOrderByCreatedAtDesc(User songLikeUser, Pageable pageable);
+    void deleteBySongLikeUserAndSong(User songLikeUser, Song song);
 }

--- a/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongRepository.java
+++ b/storage/db-core/src/main/java/com/nerd/favorite18/storage/db/core/song/repository/SongRepository.java
@@ -4,6 +4,8 @@ package com.nerd.favorite18.storage.db.core.song.repository;
 import com.nerd.favorite18.storage.db.core.song.entity.Song;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SongRepository extends JpaRepository<Song, Long> {
+import java.util.Optional;
 
+public interface SongRepository extends JpaRepository<Song, Long> {
+    Optional<Song> findFirstByIdOrderByIdDesc(Long songId);  // TODO : 충돌예상
 }


### PR DESCRIPTION
## 📝 PR Summary

즐겨 찾기는 노래 관리에서 분리하여 구현합니다.
엔티티는 먼저 추가 되어 있으므로 기능만 구현합니다.

- 사용자의 즐겨 찾기 한 노래 목록을 조회하는 기능을 추가하였습니다.
- 노래를 즐겨 찾기에 등록하는 기능을 추가하였습니다.
- 노래를 즐겨 찾기에서 삭제하는 기능을 추가하였습니다.

#### 🌲 Working Branch

feat/#23-song-like

#### 🌲 TODOs

- [x] 사용자가 즐겨 찾기 한 노래 목록 조회 기능
- [x] 즐겨 찾기 노래 추가 기능
- [x] 즐겨 찾기 노래 삭제 기능

### Related Issues

resolve #23 

### 📚 Remarks
노래 도메인 쪽과 최대한 충돌이 없도록 익셉션 쪽은 안 건드렸고, 
노래 도메인 repository 와 dto도 최소한으로 만들었습니다.
노래 쪽 로직이 추가되어도 비즈니스 로직적으로는 크게 변경될 점은 없을 것 이라고 예상하지만,
추가되는 로직에 따라서  변경 점이 생길 수 있고, 익셉션도 리팩토링 해주어야 합니다.


